### PR TITLE
Support cursor change via .esc scripts

### DIFF
--- a/ui/cursors.gd
+++ b/ui/cursors.gd
@@ -1,0 +1,43 @@
+extends Node2D
+
+var vm
+var cursors = {}
+var nope = false
+
+func set_cursor(name):
+	if nope or name.find("cursor/") < 0:
+		return
+		
+	var type = name.substr(7, name.length() - 7)
+	var texture = null
+	
+	if type in cursors:
+		texture = cursors[type]
+	else:
+		return
+	
+	# Change mouse cursor and position interaction point in the middle of texture
+	var width = texture.get_width()
+	var height = texture.get_height()
+	Input.set_custom_mouse_cursor(texture, Vector2(width / 2, height / 2))
+	
+	# Update other cursor globals without endless recursion
+	nope = true
+	vm.set_globals("cursor/", false)
+	vm.set_globals(name, true)
+	nope = false
+
+func _input(event):
+	if event.type == InputEvent.MOUSE_BUTTON and event.button_index == BUTTON_RIGHT:
+		Input.set_custom_mouse_cursor(null)
+		vm.set_globals("cursor/", false)
+
+func _ready():
+	for child in get_children():
+		if not child.is_type("Sprite"):
+			continue
+		cursors[child.get_name()] = child.get_texture()
+	
+	set_process_input(true)
+	vm = get_tree().get_root().get_node("/root/vm")
+	vm.connect("global_changed", self, "set_cursor")

--- a/ui/cursors.tscn
+++ b/ui/cursors.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=5 format=1]
+
+[ext_resource path="res://ui/cursors.gd" type="Script" id=1]
+[ext_resource path="res://scenes/rooms/test/sprites/can.png" type="Texture" id=2]
+[ext_resource path="res://scenes/rooms/test/sprites/ice_cream.png" type="Texture" id=3]
+[ext_resource path="res://scenes/rooms/test/sprites/chainsaw.png" type="Texture" id=4]
+
+[node name="cursors" type="Node2D"]
+
+script/script = ExtResource( 1 )
+
+[node name="can" type="Sprite" parent="."]
+
+texture = ExtResource( 2 )
+
+[node name="ice_cream" type="Sprite" parent="."]
+
+texture = ExtResource( 3 )
+offset = Vector2( -44, -59 )
+
+[node name="chainsaw" type="Sprite" parent="."]
+
+texture = ExtResource( 4 )
+
+


### PR DESCRIPTION
Supports change of mouse cursor via .esc scripts by instancing scene ui/cursors.tscn. The scene must have one Sprite node per available cursor with the image the cursor should change to and a name corresponding to the global set with eg. `set_global cursor/brush true`