### PR TITLE
Change .esc scripts to use the untranslated state of words

### DIFF
--- a/globals/dialog_dialog.gd
+++ b/globals/dialog_dialog.gd
@@ -210,7 +210,7 @@ func append_words(cmd):
 			vm.set_global("%s_learned" % words[word][0], true)
 		elif words[word][1] == 3:
 			vm.set_global("%s_understood" % words[word][0], true)
-			vm.set_global(word, "(%s)" % words[word][0])
+			vm.set_global(word, "%s" % words[word][0])
 	vm.set_global("words", words)
 
 func remove_words(cmd):

--- a/globals/global_vm.gd
+++ b/globals/global_vm.gd
@@ -763,7 +763,7 @@ func _ready():
 	# Set global word list
 	if not "words" in get_global_list():
 		set_global("words", {
-			"*bruuuuugh*": ["greeting", 0],
+			"*bruuuuugh*": ["(greeting)", 0],
 			"*pbbbbt*" : ["(goodbye)", 0],
 			"*proooom*" : ["(sad)", 0],
 			"*braaa*" : ["(happy)", 0],

--- a/scenes/characters/bern/bern.esc
+++ b/scenes/characters/bern/bern.esc
@@ -14,43 +14,43 @@
 
 	- "Do you think the food will run out?" [topic_food_crisis]
 		say yemm "Do you think the food will run out?"
-		say bern "!!(no)!!"
+		say bern "!!*pum*!!"
 		say yemm "I remember when we had that food shortage five years ago. We were all a little thinner by the end of the winter, but we were OK."
 
 	- "I'm worried about blood poisoning from your cuts." [topic_blood_poisoning]
 		say yemm "I'm worried about blood poisoning from your cuts."
-		say bern "!!(pain)!!"
+		say bern "!!*browmm*!!"
 		say yemm "Hopefully a clean and some poultice will be enough to prevent that."
-		say bern "!!(pain)!!"
+		say bern "!!*browmm*!!"
 
 	- "Do you know where the grain is?" [topic_missing_grain]
 		say yemm "Do you know where the grain is?"
-		say bern "!!(cave)!!"
+		say bern "!!*ghneeku*!!"
 		> [cave_understood]
 			set_global topic_cave true
 
 	- "What do you about the hidden dinosaurs?" [topic_unknown dinosaurs]
 		say yemm "What do you about the hidden dinosaurs?"
-		say bern "!!(dinosaur)!!"
+		say bern "!!*yeeduu*!!"
 
 	- "Why take the food to the cave?" [topic_cave]
 		say yemm "Why take the food to the cave?"
-		say bern "!!(dinosaur)!!"
+		say bern "!!*yeeduu*!!"
 		> [dinosaur_understood]
 			set_global topic_unknown_dinosaurs true
 
 	- "Would you like to hear about the first time I saw a dinosaur?"
 		say yemm "Would you like to hear about the first time I saw a dinosaur?"
-		say bern "!!(yes)!!"
+		say bern "!!*reehii*!!"
 		say yemm "It was a huge Triceratops."
 		say yemm "I was very young, maybe three years old? My parents were still alive. They were terrified."
 		say yemm "I can remember it so clearly. Even though I was tiny and it could have walked straight over me without noticing, the Triceratops stopped and bowed its head."
-		say bern "!!(happy)!!"
+		say bern "!!*braaa*!!"
 		say yemm "I was aware of my parents' screaming and the driver of the wagon that the Triceratops was pulling yelling, but none of that mattered."
 
 	- "Someday I hope to buy a large property outskirts of the village."
 		say yemm "Someday I hope to buy a large property outskirts of the village."
 		say yemm "I'd like to have a bigger workshop and open a nursery for orphaned dinosaurs."
-		say bern "!!(happy)!!"
+		say bern "!!*braaa*!!"
 
 set_global dinosaur_dialogue_ended true

--- a/scenes/characters/customer/customer_herk.esc
+++ b/scenes/characters/customer/customer_herk.esc
@@ -90,14 +90,14 @@
 		? reception 
 			- "Take her if you must."
 				say yemm "Take her if you must."
-				say bern "!!(sad)!!"
+				say bern "!!*proooom*!!"
 				say customer_herk "Thank you. I'll make sure she avoids any heavy loads and unnecessary walking."
 				say customer_herk "We'll take it slow going home."
 				change_scene res://scenes/rooms/reception_area/reception_area.tscn
 
 			- "She stays here."
 				say yemm "She stays here."
-				say bern "!!(happy)!!"
+				say bern "!!*braaa*!!"
 				say customer_herk "Fine. We'll make do... somehow."
 				set_global bern_stays true
 				change_scene res://scenes/rooms/reception_area/reception_area.tscn

--- a/scenes/characters/customer/customer_onda.esc
+++ b/scenes/characters/customer/customer_onda.esc
@@ -15,7 +15,7 @@
 > [customer_onda_end]
 	say customer_onda "How bad was it?"
 	say yemm "Not too bad."
-	say lull "!!(happy)!!"
+	say lull "!!*braaa*!!"
 	say customer_onda "Ha ha, you just can't keep her quiet. Come on girl, let's go carry some crates."
 
 ? reception
@@ -88,7 +88,7 @@
 		say customer_onda "I suppose it's better to lose her today than have her foot get worse. Thank you again, Farrier."
 		say yemm "Goodbye Onda."
 		say yemm "Be well, Lull."
-		say lull "!!(goodbye)!!"
+		say lull "!!*pbbbbt*!!"
 		change_scene res://scenes/rooms/reception_area/reception_area.tscn
 
 	- "*say nothing*" [customer_onda_end]

--- a/scenes/characters/customer/customer_wu.esc
+++ b/scenes/characters/customer/customer_wu.esc
@@ -7,7 +7,7 @@
 > [customer_wu_end,!customer_wu_end_intro]
 	say customer_wu "All done?"
 	say yemm "I've applied a poultice and bandaged the bruising."
-	say krik "!!(happy)!!"
+	say krik "!!*braaa*!!"
 	say customer_wu "I can tell Krik is relieved. You work so well with them."
 	set_global customer_wu_end_intro true
 

--- a/scenes/characters/krik/krik.esc
+++ b/scenes/characters/krik/krik.esc
@@ -14,38 +14,38 @@
 
 	- "Wu says that Fenn is upset." [topic_upset_fenn]
 		say yemm "Wu says that Fenn is upset."
-		say krik "!!(human)!!"
+		say krik "!!*hmndn*!!"
 		say yemm "I hope that that isn't making things difficult for the dinosaurs tending the farms."
-		say krik "!!(no)!!"
+		say krik "!!*pum*!!"
 
 	- "Do you know where the grain is?" [topic_missing_grain]
 		say yemm "Do you know where the grain is?"
-		say krik "!!(cave)!!"
+		say krik "!!*ghneeku*!!"
 		> [cave_understood]
 			set_global topic_cave true
 
 	- "What do you know about the hidden dinosaurs?" [topic_unknown_dinosaurs]
 		say yemm "What do you know about the hidden dinosaurs?"
-		say krik "!!(dinosaur)!!"
+		say krik "!!*yeeduu*!!"
 
 	- "Why take the food to the cave?" [topic_cave]
 		say yemm "Why take the food to the cave?"
-		say krik "!!(dinosaur)!!"
+		say krik "!!*yeeduu*!!"
 		> [dinosaur_understood]
 			set_global topic_unknown_dinosaurs true
 
 	- "Papa, my grandfather, tought me everything I know about dinosaurs."
 		say yemm "Papa, my grandfather, tought me everything I know about dinosaurs."
-		say krik "!!(human)!!"
+		say krik "!!*hmndn*!!"
 		say yemm "You'd have liked him. He was kind and thoughtful."
 		say yemm "Sometimes slow, but always generous."
 		say yemm "He'd definitely have liked you."
-		say krik "!!(happy)!!"
+		say krik "!!*braaa*!!"
 
 	- "I've never really had any friends."
 		say yemm "I've never really had any friends."
-		say krik "!!(dinosaur)!!"
+		say krik "!!*yeeduu*!!"
 		say yemm "Dinosaurs are like friends to me."
-		say krik "!!(happy)!!"
+		say krik "!!*braaa*!!"
 
 set_global dinosaur_dialogue_ended true

--- a/scenes/characters/lull/lull.esc
+++ b/scenes/characters/lull/lull.esc
@@ -14,26 +14,26 @@
 
 	- "So you were outside running around in the storm, were you?" [topic_outside_in_storm]
 		say yemm "So you were outside running around in the storm, were you?"
-		say lull "!!(pain)!!"
+		say lull "!!*browmm*!!"
 		say yemm "That's pretty dangerous, especially this time of year."
-		say lull "!!(yes)!!"
+		say lull "!!*reehii*!!"
 
 	- "I guess you don't really like the lightning, huh?" [topic_lightning]
 		say yemm "I guess you don't really like the lightning, huh?"
-		say lull "!!(sad)!!"
+		say lull "!!*proooom*!!"
 		say yemm "I don't really like it either."
 
 	- "Do you know why we're called farriers?"
 		say yemm "Do you know why we're called farriers?"
-		say lull "!!(no)!!"
+		say lull "!!*pum*!!"
 		say yemm "My grandfather, Papa, told me that a long time ago, our family used to look after horses. Do you know what a horse is?"
-		say lull "!!(no)!!"
+		say lull "!!*pum*!!"
 		say yemm "They're four legged and as big as a triceratops. They're very fast and graceful."
 		say yemm "I've never seen one, but there were pictures in the books that Papa let me read."
 
 	- "Do you have a favourite food?"
 		say yemm "Do you have a favourite food?"
-		say lull "!!(food)!!"
+		say lull "!!*drrrrgl*!!"
 		say yemm "Strawberries are my favourite."
 
 set_global dinosaur_dialogue_ended true


### PR DESCRIPTION
Used find+sed to change words. Picked the first key for cave, *ghneeku*, which also has a dict entry with *harroot* as key. Added enclosing parentheses around the translation for "greeting", though I'm not sure it that's something that's being used, since that was something I added for testing a few days ago.

Works in my testing with the first dino
* Picked "Do you know..."
* Foot work
* Picked "*pum*" (to learn)
* Foot work
* Picked "Do you know..." (to understand)
* Foot work
* Picked "Do you know..."

Word is now translated. Not picking "*pum*" in step 3 wastes the learning opportunity.